### PR TITLE
Removing cgroup mount

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,4 @@ RUN sed -i -e 's/^\(Defaults\s*requiretty\)/#--- \1/'  /etc/sudoers
 RUN mkdir -p /etc/ansible
 RUN echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 
-VOLUME ["/sys/fs/cgroup"]
 CMD ["/usr/lib/systemd/systemd"]


### PR DESCRIPTION
With newer versions of containerd mounting cgroup seems to cause the error: Failed to connect to bus: No such file or directory
After removing this mount I was able to use systemd inside of my container

Tested on:

|  system | containerd version | docker version |
|---------------------|--------------------------|---------------------|
| Kubuntu 22.04 | containerd.io: 1.6.7-1 |  docker-ce: 5:20.10.17 (with root) | 

command run: 
```
docker run --privileged docker-rockylinux8-ansible:latest 
```

molecule yml
```yaml
platforms:
  - name: test-one
    image: docker-rockylinux8-ansible
    command: ${MOLECULE_DOCKER_COMMAND: - ""}
    privileged: true
    pre_build_image: true
```
 